### PR TITLE
feat: サマリー Excel の上部に金額合計行を追加 (#3)

### DIFF
--- a/src-app/services/excel/exporter.test.ts
+++ b/src-app/services/excel/exporter.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+
+// pdfjs-dist の import チェーンを迂回（テスト環境では不要）
+// pdfExtractor.ts が pdfjsLib.GlobalWorkerOptions に代入するためダミーで埋める
+vi.mock("pdfjs-dist", () => ({
+  GlobalWorkerOptions: {},
+  getDocument: vi.fn(),
+}));
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  exists: vi.fn(),
+}));
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openPath: vi.fn(),
+}));
+vi.mock("../tauri/commands", () => ({
+  getRootDirectory: vi.fn(),
+}));
+
+import ExcelJS from "exceljs";
+import { calculateJpyTotal } from "./exporter";
+import type { ReceiptData } from "../../types/receipt";
+import {
+  ExcelColumnLabel,
+  generateSheetColumns,
+  getColumnIndex,
+} from "../../types/excel";
+
+function makeReceipt(overrides: Partial<ReceiptData>): ReceiptData {
+  return {
+    id: "test-id",
+    file: "test.pdf",
+    filePath: "/tmp/test.pdf",
+    status: "success",
+    ...overrides,
+  };
+}
+
+describe("calculateJpyTotal", () => {
+  it("sums JPY-only receipts", () => {
+    const total = calculateJpyTotal([
+      makeReceipt({ amount: 100, currency: "JPY" }),
+      makeReceipt({ amount: 250, currency: "JPY" }),
+    ]);
+    expect(total).toBe(350);
+  });
+
+  it("treats undefined currency as JPY", () => {
+    const total = calculateJpyTotal([
+      makeReceipt({ amount: 100 }),
+      makeReceipt({ amount: 200, currency: "JPY" }),
+    ]);
+    expect(total).toBe(300);
+  });
+
+  it("excludes non-JPY currencies", () => {
+    const total = calculateJpyTotal([
+      makeReceipt({ amount: 100, currency: "JPY" }),
+      makeReceipt({ amount: 1000, currency: "USD" }),
+      makeReceipt({ amount: 500, currency: "EUR" }),
+    ]);
+    expect(total).toBe(100);
+  });
+
+  it("returns 0 for empty input", () => {
+    expect(calculateJpyTotal([])).toBe(0);
+  });
+
+  it("ignores receipts with missing amount", () => {
+    const total = calculateJpyTotal([
+      makeReceipt({ amount: 100, currency: "JPY" }),
+      makeReceipt({ currency: "JPY", status: "pending" }),
+    ]);
+    expect(total).toBe(100);
+  });
+});
+
+describe("Excel summary structure (in-memory round trip)", () => {
+  /**
+   * generateSummaryExcel と同じ構造を in-memory で組み立てる軽量版。
+   * 画像処理と Tauri I/O を除外し、行構造とフォーマット検出のみを検証する。
+   */
+  async function buildInMemorySummary(
+    receipts: ReceiptData[],
+  ): Promise<ExcelJS.Buffer> {
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet("Summary");
+    sheet.columns = generateSheetColumns();
+    const jpyTotal = calculateJpyTotal(receipts);
+    sheet.spliceRows(1, 0, ["合計金額", jpyTotal]);
+    sheet.views = [{ state: "frozen", ySplit: 2 }];
+
+    for (const r of receipts) {
+      sheet.addRow({
+        [ExcelColumnLabel.FileName]: r.file,
+        [ExcelColumnLabel.OriginalFileLink]: r.filePath,
+        [ExcelColumnLabel.Date]: r.date ?? "",
+        [ExcelColumnLabel.Merchant]: r.merchant ?? "",
+        [ExcelColumnLabel.Amount]: r.amount ?? null,
+        [ExcelColumnLabel.Currency]: r.currency ?? "",
+        [ExcelColumnLabel.ReceiverName]: r.receiverName ?? "",
+        [ExcelColumnLabel.AccountCategory]: r.accountCategory ?? "",
+        [ExcelColumnLabel.Note]: r.note ?? "",
+        [ExcelColumnLabel.ValidationIssues]: "",
+      });
+    }
+
+    return workbook.xlsx.writeBuffer();
+  }
+
+  it("places total row at row 1 with JPY-formatted total", async () => {
+    const receipts = [
+      makeReceipt({
+        date: "2026-04-01",
+        merchant: "A",
+        amount: 1000,
+        currency: "JPY",
+      }),
+      makeReceipt({
+        date: "2026-04-02",
+        merchant: "B",
+        amount: 500,
+        currency: "JPY",
+      }),
+    ];
+    const buffer = await buildInMemorySummary(receipts);
+
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(buffer as ArrayBuffer);
+    const sheet = wb.getWorksheet("Summary")!;
+
+    expect(String(sheet.getRow(1).getCell(1).value)).toBe("合計金額");
+    expect(Number(sheet.getRow(1).getCell(2).value)).toBe(1500);
+  });
+
+  it("places header at row 2 and data starting from row 3", async () => {
+    const receipts = [
+      makeReceipt({
+        date: "2026-04-01",
+        merchant: "Cafe",
+        amount: 800,
+        currency: "JPY",
+      }),
+    ];
+    const buffer = await buildInMemorySummary(receipts);
+
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(buffer as ArrayBuffer);
+    const sheet = wb.getWorksheet("Summary")!;
+
+    expect(String(sheet.getRow(2).getCell(1).value)).toBe("ファイル名");
+    const merchantCol = getColumnIndex(ExcelColumnLabel.Merchant);
+    expect(String(sheet.getRow(3).getCell(merchantCol).value)).toBe("Cafe");
+  });
+
+  it("freezes the first 2 rows (total + header)", async () => {
+    const buffer = await buildInMemorySummary([]);
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(buffer as ArrayBuffer);
+    const sheet = wb.getWorksheet("Summary")!;
+
+    const view = sheet.views[0] as { state: string; ySplit: number };
+    expect(view.state).toBe("frozen");
+    expect(view.ySplit).toBe(2);
+  });
+});

--- a/src-app/services/excel/exporter.ts
+++ b/src-app/services/excel/exporter.ts
@@ -18,6 +18,21 @@ import { getRootDirectory } from "../tauri/commands";
 
 type SupportedImageExtension = "jpeg" | "png";
 
+/** 合計行の A 列ラベル */
+const TOTAL_ROW_LABEL = "合計金額";
+
+/**
+ * JPY 合計金額を計算する
+ * - currency が undefined または "JPY" のレシートのみ集計対象
+ * - amount が undefined の場合は 0 として扱う
+ */
+export function calculateJpyTotal(receipts: ReceiptData[]): number {
+  return receipts.reduce((sum, r) => {
+    if (r.currency && r.currency !== "JPY") return sum;
+    return sum + (r.amount ?? 0);
+  }, 0);
+}
+
 /**
  * ファイルパスから画像拡張子を取得
  */
@@ -126,8 +141,13 @@ export async function loadReceiptsFromExcel(
 
   const receipts: ReceiptData[] = [];
 
+  // 1 行目に合計行があるか判定（A1 セルが "合計金額" なら新フォーマット）
+  const firstCellValue = String(sheet.getRow(1).getCell(1).value ?? "");
+  const hasTotalRow = firstCellValue === TOTAL_ROW_LABEL;
+  const headerRowIndex = hasTotalRow ? 2 : 1;
+
   // ヘッダー行から新フォーマットか判定（"宛名"列の有無）
-  const headerRow = sheet.getRow(1);
+  const headerRow = sheet.getRow(headerRowIndex);
   let isNewFormat = false;
   headerRow.eachCell((cell) => {
     if (String(cell.value) === "宛名") {
@@ -148,7 +168,7 @@ export async function loadReceiptsFromExcel(
   };
 
   sheet.eachRow((row, rowNumber) => {
-    if (rowNumber === 1) return;
+    if (rowNumber <= headerRowIndex) return;
 
     const fileColIndex = isNewFormat
       ? getColumnIndex(ExcelColumnLabel.FileName)
@@ -331,11 +351,22 @@ async function generateSummaryExcel(
   const sheet = workbook.addWorksheet("Summary");
 
   // カラム設定（types/excel.ts の定義から生成）
+  // この時点で 1 行目にヘッダー行が自動配置される
   sheet.columns = generateSheetColumns();
 
-  // ヘッダー行のスタイル
-  sheet.views = [{ state: "frozen", ySplit: 1 }];
-  sheet.getRow(1).font = { bold: true };
+  // 合計行を 1 行目に挿入し、ヘッダー行を 2 行目へシフト
+  // データ行の addRow は 3 行目以降に積まれるので、画像アンカーも自然に追従する
+  const jpyTotal = calculateJpyTotal(receipts);
+  sheet.spliceRows(1, 0, [TOTAL_ROW_LABEL, jpyTotal]);
+
+  // 合計行（1 行目）のスタイル
+  const totalRow = sheet.getRow(1);
+  totalRow.font = { bold: true, size: 12 };
+  totalRow.getCell(2).numFmt = '"¥"#,##0';
+
+  // ヘッダー行（2 行目）のスタイル + 合計行とヘッダー行の 2 行を固定
+  sheet.views = [{ state: "frozen", ySplit: 2 }];
+  sheet.getRow(2).font = { bold: true };
 
   // 日付順でソート（昇順、undefined は末尾）
   const sortedReceipts = sortReceiptsByDate(receipts);


### PR DESCRIPTION
## Summary

サマリー Excel (`YYYYMM-summary.xlsx`) の 1 行目に「合計金額」行を追加し、税理士チェック時にシート全体の合計を一目で確認できるようにした。ヘッダー行は 2 行目へシフトし、データ行は 3 行目以降に配置される。

## Closes

Closes #3

## Changes

- `calculateJpyTotal(receipts)`: JPY 通貨のみを集計するヘルパーを新設（外貨は除外、`currency === undefined` は JPY 扱い）
- `generateSummaryExcel`: `sheet.spliceRows(1, 0, [...])` で合計行を 1 行目に挿入し、`sheet.views.ySplit` を 2 に変更（合計行 + ヘッダー行をフリーズ）
- `loadReceiptsFromExcel`: A1 セルが「合計金額」なら新フォーマットと判定し、データ読み込みを 3 行目以降から開始。旧フォーマット（合計行なし）は従来どおり読み込み可能（後方互換）
- `exporter.test.ts`: `calculateJpyTotal` と Excel 構造の round-trip テストを追加（pdfjs-dist / Tauri モジュールはモック）

## Test Plan

### 検証項目

- [x] [UI] サマリー Excel 生成 → 1 行目に「合計金額」と総額が表示される
- [x] [UI] ヘッダー行は 2 行目に表示され、フリーズが効いている
- [x] [LOGIC] receipts の amount 合計と表示される合計値が完全一致する
- [x] [LOGIC] 新フォーマットで生成された Excel を再読み込み → 合計行をレシートとして誤読み込みしない
- [x] [LOGIC] 旧フォーマット（合計行なし）の Excel も従来どおり読み込める
- [x] [BUILD] `pnpm lint:ts` (tsc --noEmit) がエラーなく完了する
- [x] [BUILD] `pnpm build` (vite build) がエラーなく完了する
- [ ] [BUILD] `pnpm tauri build` がエラーなく完了する（ネイティブビルド、CI または手元でレビュアー検証）

## Verification

```
$ pnpm test:run
✓ src-app/App.test.tsx (1 test)
✓ src-app/services/excel/exporter.test.ts (8 tests)
Test Files  2 passed (2)
     Tests  9 passed (9)
```

UI 検証は手動で実施し、1 行目の合計金額表示・2 行目のヘッダー固定（ySplit=2）が期待どおりであることを確認済み。